### PR TITLE
feat: adicionar camada extra de segurança para o app

### DIFF
--- a/src/registryAPI/app/auth/guards/admin-jwt.guard.ts
+++ b/src/registryAPI/app/auth/guards/admin-jwt.guard.ts
@@ -6,7 +6,7 @@ import {
 	Injectable,
 } from '@nestjs/common';
 import { JwtService } from '@nestjs/jwt';
-import { IAccessTokenBody } from '../tokenTypes';
+import { IAccessTokenBody, authHeaders } from '../tokenTypes';
 import { UserRepo } from '@registry:app/repositories/user';
 import { GuardErrors } from '@registry:app/errors/guard';
 import { Request } from 'express';
@@ -34,7 +34,9 @@ export class AdminJwt implements CanActivate {
 
 	async canActivate(context: ExecutionContext): Promise<boolean> {
 		const req = context.switchToHttp().getRequest<Request>();
-		const rawToken = req?.headers?.authorization;
+		const rawToken = req?.headers?.[authHeaders.userToken]
+			? String(req?.headers[authHeaders.userToken])
+			: '';
 
 		const condominiumId = req.params?.condominiumId;
 		if (!condominiumId)

--- a/src/registryAPI/app/auth/guards/jwt.guard.ts
+++ b/src/registryAPI/app/auth/guards/jwt.guard.ts
@@ -1,7 +1,7 @@
 import { CanActivate, ExecutionContext, Injectable } from '@nestjs/common';
 import { JwtService } from '@nestjs/jwt';
 import { UserRepo } from '@registry:app/repositories/user';
-import { IAccessTokenBody } from '../tokenTypes';
+import { IAccessTokenBody, authHeaders } from '../tokenTypes';
 import { GuardErrors } from '@registry:app/errors/guard';
 import { Request } from 'express';
 import { UUID } from '@registry:app/entities/VO';
@@ -28,7 +28,9 @@ export class JwtGuard implements CanActivate {
 
 	async canActivate(context: ExecutionContext): Promise<boolean> {
 		const req = context.switchToHttp().getRequest<Request>();
-		const rawToken = req?.headers?.authorization;
+		const rawToken = req?.headers?.[authHeaders.userToken]
+			? String(req?.headers[authHeaders.userToken])
+			: '';
 
 		const token = rawToken?.split(' ')[1];
 		if (!token) throw new GuardErrors({ message: 'Token não encontrado' });

--- a/src/registryAPI/app/auth/guards/super-admin-jwt.guard.ts
+++ b/src/registryAPI/app/auth/guards/super-admin-jwt.guard.ts
@@ -6,7 +6,7 @@ import {
 	Injectable,
 } from '@nestjs/common';
 import { JwtService } from '@nestjs/jwt';
-import { IAccessTokenBody } from '../tokenTypes';
+import { IAccessTokenBody, authHeaders } from '../tokenTypes';
 import { UserRepo } from '@registry:app/repositories/user';
 import { UUID } from '@registry:app/entities/VO';
 import { GuardErrors } from '@registry:app/errors/guard';
@@ -34,7 +34,9 @@ export class SuperAdminJwt implements CanActivate {
 
 	async canActivate(context: ExecutionContext): Promise<boolean> {
 		const req = context.switchToHttp().getRequest<Request>();
-		const rawToken = req?.headers?.authorization;
+		const rawToken = req?.headers?.[authHeaders.userToken]
+			? String(req?.headers[authHeaders.userToken])
+			: '';
 
 		const condominiumId = req.params?.condominiumId;
 		if (!condominiumId)

--- a/src/registryAPI/app/auth/guards/tests/admin-jwt.spec.ts
+++ b/src/registryAPI/app/auth/guards/tests/admin-jwt.spec.ts
@@ -44,7 +44,7 @@ describe('Admin Jwt guard test', () => {
 				condominiumId: condominiumRelUser.condominiumId.value,
 			},
 			headers: {
-				authorization: `Bearer ${tokens.accessToken}`,
+				'user-token': `Bearer ${tokens.accessToken}`,
 			},
 		});
 
@@ -69,7 +69,7 @@ describe('Admin Jwt guard test', () => {
 				condominiumId: condominiumRelUser.condominiumId.value,
 			},
 			headers: {
-				authorization: `Bearer ${tokens.accessToken}`,
+				'user-token': `Bearer ${tokens.accessToken}`,
 			},
 		});
 
@@ -90,7 +90,7 @@ describe('Admin Jwt guard test', () => {
 
 		const context = createMockExecutionContext({
 			headers: {
-				authorization: `Bearer ${tokens.accessToken}`,
+				'user-token': `Bearer ${tokens.accessToken}`,
 			},
 		});
 
@@ -112,7 +112,7 @@ describe('Admin Jwt guard test', () => {
 				condominiumId: UUID.genV4().value,
 			},
 			headers: {
-				authorization: `Bearer ${tokens.accessToken}`,
+				'user-token': `Bearer ${tokens.accessToken}`,
 			},
 		});
 
@@ -143,7 +143,7 @@ describe('Admin Jwt guard test', () => {
 				condominiumId: UUID.genV4().value,
 			},
 			headers: {
-				authorization: 'Bearer malformedtoken',
+				'user-token': 'Bearer malformedtoken',
 			},
 		});
 		await expect(adminJwtGuard.canActivate(context)).rejects.toThrow(

--- a/src/registryAPI/app/auth/guards/tests/checkTFACode.spec.ts
+++ b/src/registryAPI/app/auth/guards/tests/checkTFACode.spec.ts
@@ -54,7 +54,7 @@ describe('Check TFA Code guard test', () => {
 		const code = await genCode(user);
 		const context = createMockExecutionContext({
 			headers: {
-				authorization: `Bearer ${code}`,
+				'user-token': `Bearer ${code}`,
 			},
 			body: {
 				email: user.email.value,
@@ -89,7 +89,7 @@ describe('Check TFA Code guard test', () => {
 
 		const context = createMockExecutionContext({
 			headers: {
-				authorization: `Bearer ${btoa(
+				'user-token': `Bearer ${btoa(
 					JSON.stringify({ msg: 'wrong' }),
 				)}.${btoa(JSON.stringify({ msg: 'token' }))}`,
 			},

--- a/src/registryAPI/app/auth/guards/tests/jwt.spec.ts
+++ b/src/registryAPI/app/auth/guards/tests/jwt.spec.ts
@@ -37,7 +37,7 @@ describe('Jwt guard test', () => {
 
 		const context = createMockExecutionContext({
 			headers: {
-				authorization: `Bearer ${tokens.accessToken}`,
+				'user-token': `Bearer ${tokens.accessToken}`,
 			},
 		});
 
@@ -53,7 +53,7 @@ describe('Jwt guard test', () => {
 
 		const context = createMockExecutionContext({
 			headers: {
-				authorization: `Bearer ${tokens.accessToken}`,
+				'user-token': `Bearer ${tokens.accessToken}`,
 			},
 		});
 
@@ -77,7 +77,7 @@ describe('Jwt guard test', () => {
 	it('should throw one error - malformed token', async () => {
 		const context = createMockExecutionContext({
 			headers: {
-				authorization: 'Bearer malformedtoken',
+				'user-token': 'Bearer malformedtoken',
 			},
 		});
 		await expect(jwtGuard.canActivate(context)).rejects.toThrow(

--- a/src/registryAPI/app/auth/guards/tests/super-admin-jwt.spec.ts
+++ b/src/registryAPI/app/auth/guards/tests/super-admin-jwt.spec.ts
@@ -44,7 +44,7 @@ describe('Super Admin Jwt guard test', () => {
 				condominiumId: condominiumRelUser.condominiumId.value,
 			},
 			headers: {
-				authorization: `Bearer ${tokens.accessToken}`,
+				'user-token': `Bearer ${tokens.accessToken}`,
 			},
 		});
 
@@ -69,7 +69,7 @@ describe('Super Admin Jwt guard test', () => {
 				condominiumId: condominiumRelUser.condominiumId.value,
 			},
 			headers: {
-				authorization: `Bearer ${tokens.accessToken}`,
+				'user-token': `Bearer ${tokens.accessToken}`,
 			},
 		});
 
@@ -90,7 +90,7 @@ describe('Super Admin Jwt guard test', () => {
 
 		const context = createMockExecutionContext({
 			headers: {
-				authorization: `Bearer ${tokens.accessToken}`,
+				'user-token': `Bearer ${tokens.accessToken}`,
 			},
 		});
 
@@ -112,7 +112,7 @@ describe('Super Admin Jwt guard test', () => {
 				condominiumId: UUID.genV4().value,
 			},
 			headers: {
-				authorization: `Bearer ${tokens.accessToken}`,
+				'user-token': `Bearer ${tokens.accessToken}`,
 			},
 		});
 
@@ -143,7 +143,7 @@ describe('Super Admin Jwt guard test', () => {
 				condominiumId: UUID.genV4().value,
 			},
 			headers: {
-				authorization: 'Bearer malformedtoken',
+				'user-token': 'Bearer malformedtoken',
 			},
 		});
 		await expect(adminJwtGuard.canActivate(context)).rejects.toThrow(

--- a/src/registryAPI/app/auth/tokenTypes.ts
+++ b/src/registryAPI/app/auth/tokenTypes.ts
@@ -1,3 +1,7 @@
+export const authHeaders = {
+	userToken: 'user-token',
+};
+
 export enum TokenType {
 	accessToken = 'Access Token',
 	refreshToken = 'Refresh Token',


### PR DESCRIPTION
movendo o header 'authorization' para 'user-token', permitindo que provedores externos solicitem uma API key dos usuários pelo header de autorização